### PR TITLE
[VGRAPH-16] Fix Graphite web bug (':' in metric name)

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1152,7 +1152,8 @@ def aliasByNode(requestContext, seriesList, *nodes):
   if type(nodes) is int:
     nodes=[nodes]
   for series in seriesList:
-    metric_pieces = re.search('(?:.*\()?(?P<name>[-\w*\.]+)(?:,|\)?.*)?',series.name).groups()[0].split('.')
+    # fetch inner expression containing metric name, stop at first pattern then split on dot character
+    metric_pieces = re.search('^(?:\w+\()*([^\s,)]+)',series.name).groups()[0].split('.')
     series.name = '.'.join(metric_pieces[n] for n in nodes)
   return seriesList
 


### PR DESCRIPTION
aliasByNode() failed with metrics containing special characters like ':' 
