### PR TITLE
Linear complexity for movingAverage function

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -958,10 +958,17 @@ def movingAverage(requestContext, seriesList, windowSize):
     newSeries = TimeSeries(newName, series.start, series.end, series.step, [])
     newSeries.pathExpression = newName
 
-    offset = len(bootstrap) - len(series)
-    for i in range(len(series)):
-      window = bootstrap[i + offset - windowPoints:i + offset]
-      newSeries.append(safeAvg(window))
+    window_sum = safeSum(bootstrap[:windowPoints])
+    count = safeLen(bootstrap[:windowPoints])
+    newSeries.append(safeDiv(window_sum, count))
+    for n, last in enumerate(bootstrap[windowPoints:-1]):
+      if bootstrap[n] is not None:
+        window_sum -= bootstrap[n]
+        count      -= 1
+      if last is not None:
+        window_sum += last
+        count      += 1
+      newSeries.append(safeDiv(window_sum, count))
 
     result.append(newSeries)
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -403,6 +403,27 @@ class FunctionsTest(TestCase):
             result = functions.changed({}, series)
             self.assertEqual(result, expected)
 
+    def test_movingAverage(self):
+        config = [
+            [[1,1,1,1,2,2,2,2,3], [0.0, 0.3333333333333333, 0.6666666666666666, 1.0, 1.0, 1.3333333333333333, 1.6666666666666667, 2.0, 2.0]]
+            ]
+        for i, c in enumerate(config):
+            name = "moving.average.test{0}".format(i + 1)
+
+            savedSeries = TimeSeries(name, 0,1 ,1, [0] * 3),
+            with patch.object(functions, "evaluateTarget", return_value=savedSeries):
+                serie  = TimeSeries(name, 0, 1, 1, c[0])
+                # pathExpression is necessary to fetch extra points to compute moving average
+                serie.pathExpression = "tempPath"
+                series = [serie]
+                expected = [TimeSeries("movingAverage(%s,3)" % name, 0, 1, 1, c[1])]
+                context = {
+                    'startTime': datetime(1970, 1, 1, 0, 9, 0, 0, pytz.timezone(settings.TIME_ZONE)),
+                    'endTime': datetime(1970, 1, 1, 0, 9, 0, 8, pytz.timezone(settings.TIME_ZONE))
+                    }
+                result = functions.movingAverage(context, series, 3)
+                self.assertEqual(result, expected)
+
     def test_multiplySeriesWithWildcards(self):
         seriesList1 = [
             TimeSeries('web.host-1.avg-response.value',0,1,1,[1,10,11]),


### PR DESCRIPTION
The previous version recomputed the whole sum at each iterations.
When the moving average window is large (a few days), it makes computation too long.

This change make computation time linear instead.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo-forks/graphite-web/3)

<!-- Reviewable:end -->
