### PR TITLE
Add MAX_FOUND_METRICS parameter to prevent from too large metrics

### DIFF
--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -86,6 +86,10 @@ LOG_ROTATION = True
 LOG_ROTATION_COUNT = 1
 MAX_FETCH_RETRIES = 2
 
+# This settings limit metrics find to prevent from too large query
+METRICS_FIND_WARNING_THRESHOLD = float('Inf') # Print a warning if more than X metrics are returned
+METRICS_FIND_FAILURE_THRESHOLD = float('Inf') # Fail if more than X metrics are returned
+
 #Remote rendering settings
 REMOTE_RENDERING = False #if True, rendering is delegated to RENDERING_HOSTS
 RENDERING_HOSTS = []


### PR DESCRIPTION
Enable limiting metric list retuned by the StandardFinder.
Do not limit as default.