### PR TITLE
Set cairocffi dependency to v.0.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ django-tagging==0.4.6
 gunicorn
 pytz
 pyparsing
-cairocffi
+cairocffi==0.9.0
 git+git://github.com/graphite-project/whisper.git#egg=whisper
 # Ceres is optional
 # git+git://github.com/graphite-project/ceres.git#egg=ceres


### PR DESCRIPTION
 - This to avoid error "RuntimeError: cairocffi does not support
   Python 2.x anymore. Please use Python 3 or install an older
   version of cairocffi."

Signed-off-by: Jean-Francois Weber-Marx <jfwm@hotmail.com>