### PR TITLE
Fix cairocffi dependency to v.0.9.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ try:
         ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=list(webapp_content.items()) + storage_dirs + conf_files + examples,
-      install_requires=['Django>=1.8,<1.11.99', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi', 'urllib3', 'scandir', 'six'],
+      install_requires=['Django>=1.8,<1.11.99', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi==0.9.0', 'urllib3', 'scandir', 'six'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',


### PR DESCRIPTION
It was already done in requirement.txt, but setup.py was forgotten.

Signed-off-by: Jean-Francois Weber-Marx <jfwm@hotmail.com>